### PR TITLE
[1.x] chore: bump itsgoingd/clockwork to ^5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": "^8.2",
         "flarum/core": "^1.8",
-        "itsgoingd/clockwork": "5.1.5"
+        "itsgoingd/clockwork": "^5.3"
     },
     "authors": [
         {


### PR DESCRIPTION
## Summary

- Bumps `itsgoingd/clockwork` from `5.1.5` to `^5.3`

## Compatibility notes

- **`DataSource::reset()` / `extend()`** — new interface methods in 5.3 have default implementations in the base `DataSource` class; `FlarumDataSource` requires no changes.
- **Domain restriction** — 5.3 defaults `enable` to `null` (localhost-only), but the service provider passes `'enable' => true` to `Clockwork::init()`, so behaviour is unchanged.
- **`web.path` default changed to `false`** — not relevant; Flarum serves the Clockwork UI via its own routes.
- PHPStan reports no errors.