### PR TITLE
[1.x] feat: add queue job and Redis command tracking

### DIFF
--- a/src/Clockwork/QueueJobTracker.php
+++ b/src/Clockwork/QueueJobTracker.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of fof/clockwork.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Clockwork\Clockwork;
+
+use Clockwork\Request\Request;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Jobs\SyncJob;
+
+class QueueJobTracker
+{
+    /**
+     * @var Container
+     */
+    private $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    public function listenToEvents()
+    {
+        $this->container['events']->listen(JobProcessing::class, function (JobProcessing $event) {
+            // Sync jobs are recorded as part of the parent HTTP request
+            if ($event->job instanceof SyncJob) {
+                return;
+            }
+
+            $payload = $event->job->payload();
+
+            if (!isset($payload['clockwork_id'])) {
+                return;
+            }
+
+            $request = new Request(['id' => $payload['clockwork_id']]);
+
+            if (isset($payload['clockwork_parent_id'])) {
+                $request->setParent($payload['clockwork_parent_id']);
+            }
+
+            $this->container->make('clockwork')->reset()->request($request);
+
+            $this->container['clockwork.queue']->setCurrentRequestId($request->id);
+        });
+
+        $this->container['events']->listen(JobProcessed::class, function (JobProcessed $event) {
+            $this->processJob($event->job);
+        });
+
+        $this->container['events']->listen(JobFailed::class, function (JobFailed $event) {
+            $this->processJob($event->job, $event->exception);
+        });
+    }
+
+    protected function processJob($job, ?\Throwable $exception = null)
+    {
+        // Sync jobs are recorded as part of the parent HTTP request
+        if ($job instanceof SyncJob) {
+            return;
+        }
+
+        $payload = $job->payload();
+
+        if (!isset($payload['clockwork_id'])) {
+            return;
+        }
+
+        $unserialized = isset($payload['data']['command']) ? unserialize($payload['data']['command']) : null;
+
+        if (!$unserialized) {
+            return;
+        }
+
+        $clockwork = $this->container->make('clockwork');
+
+        if ($exception) {
+            $clockwork->error($exception->getMessage(), ['exception' => $exception]);
+        }
+
+        $clockwork
+            ->resolveAsQueueJob(
+                get_class($unserialized),
+                $payload['displayName'],
+                $job->hasFailed() ? 'failed' : ($job->isReleased() ? 'released' : 'done'),
+                $unserialized,
+                $job->getQueue(),
+                $job->getConnectionName(),
+                array_filter([
+                    'maxTries'     => $payload['maxTries'] ?? null,
+                    'delaySeconds' => $payload['delaySeconds'] ?? null,
+                    'timeout'      => $payload['timeout'] ?? null,
+                    'timeoutAt'    => $payload['timeoutAt'] ?? null,
+                ])
+            )
+            ->storeRequest();
+    }
+}

--- a/src/Provider/ClockworkServiceProvider.php
+++ b/src/Provider/ClockworkServiceProvider.php
@@ -18,7 +18,6 @@ use Clockwork\DataSource\LaravelQueueDataSource;
 use Clockwork\DataSource\LaravelRedisDataSource;
 use Clockwork\DataSource\MonologDataSource;
 use Clockwork\DataSource\XdebugDataSource;
-use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Clockwork\Request\Log;
 use Clockwork\Support\Vanilla\Clockwork;
 use Flarum\Foundation\Paths;
@@ -27,6 +26,7 @@ use FoF\Clockwork\Clockwork\FlarumAuthenticator;
 use FoF\Clockwork\Clockwork\FlarumDataSource;
 use FoF\Clockwork\Clockwork\QueueJobTracker;
 use FoF\Clockwork\Middleware\ClockworkMiddleware;
+use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Illuminate\Support\ServiceProvider;
 
 class ClockworkServiceProvider extends ServiceProvider
@@ -42,6 +42,7 @@ class ClockworkServiceProvider extends ServiceProvider
                 $this->enableRedisEvents();
                 $this->app['clockwork.redis']->listenToEvents();
             }
+
             return;
         }
 

--- a/src/Provider/ClockworkServiceProvider.php
+++ b/src/Provider/ClockworkServiceProvider.php
@@ -14,14 +14,18 @@ namespace FoF\Clockwork\Provider;
 use Clockwork\DataSource\EloquentDataSource;
 use Clockwork\DataSource\LaravelCacheDataSource;
 use Clockwork\DataSource\LaravelEventsDataSource;
+use Clockwork\DataSource\LaravelQueueDataSource;
+use Clockwork\DataSource\LaravelRedisDataSource;
 use Clockwork\DataSource\MonologDataSource;
 use Clockwork\DataSource\XdebugDataSource;
+use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Clockwork\Request\Log;
 use Clockwork\Support\Vanilla\Clockwork;
 use Flarum\Foundation\Paths;
 use Flarum\Group\Group;
 use FoF\Clockwork\Clockwork\FlarumAuthenticator;
 use FoF\Clockwork\Clockwork\FlarumDataSource;
+use FoF\Clockwork\Clockwork\QueueJobTracker;
 use FoF\Clockwork\Middleware\ClockworkMiddleware;
 use Illuminate\Support\ServiceProvider;
 
@@ -29,7 +33,15 @@ class ClockworkServiceProvider extends ServiceProvider
 {
     public function boot()
     {
+        $this->app['clockwork.queue.tracker']->listenToEvents();
+
         if ($this->runningInConsole()) {
+            $this->app['clockwork.eloquent']->listenToEvents();
+            $this->app['clockwork.cache']->listenToEvents();
+            if ($this->redisAvailable()) {
+                $this->enableRedisEvents();
+                $this->app['clockwork.redis']->listenToEvents();
+            }
             return;
         }
 
@@ -37,6 +49,16 @@ class ClockworkServiceProvider extends ServiceProvider
         $this->app['clockwork.cache']->listenToEvents();
         $this->app['clockwork.flarum']->listenToEvents();
         $this->app['clockwork.events']->listenToEvents();
+
+        if ($this->redisAvailable()) {
+            $this->enableRedisEvents();
+            $this->app['clockwork.redis']->listenToEvents();
+        }
+
+        $this->app['clockwork.queue']->listenToEvents();
+        $this->app['clockwork.queue']->setCurrentRequestId(
+            $this->app->make('clockwork')->getClockwork()->request()->id
+        );
 
         // Remove the clockwork middleware from API Client handling
         $this->app->extend('flarum.api_client.exclude_middleware', function (array $exclusions) {
@@ -48,7 +70,56 @@ class ClockworkServiceProvider extends ServiceProvider
 
     public function register()
     {
+        $this->app->singleton('clockwork.queue', function ($app) {
+            /** @var \Illuminate\Queue\Queue $connection */
+            $connection = $app->make('flarum.queue.connection');
+
+            return new LaravelQueueDataSource($connection);
+        });
+
+        $this->app->singleton('clockwork.queue.tracker', function ($app) {
+            return new QueueJobTracker($app);
+        });
+
+        $this->app->singleton('clockwork.redis', function ($app) {
+            return new LaravelRedisDataSource($app['events']);
+        });
+
         if ($this->runningInConsole()) {
+            $this->app->singleton('clockwork.log', function () {
+                return new Log();
+            });
+
+            $this->app->singleton('clockwork.eloquent', function ($app) {
+                return new EloquentDataSource($app['db'], $app['events']);
+            });
+
+            $this->app->singleton('clockwork.cache', function ($app) {
+                return new LaravelCacheDataSource($app['events']);
+            });
+
+            $this->app->singleton('clockwork', function ($app) {
+                $paths = resolve(Paths::class);
+
+                /** @var Clockwork|\Clockwork\Clockwork $clockwork */
+                $clockwork = Clockwork::init([
+                    'enable'             => true,
+                    'storage_files_path' => $paths->storage.'/clockwork',
+                ]);
+
+                $clockwork
+                    ->addDataSource(new MonologDataSource($app['log']))
+                    ->addDataSource($app['clockwork.eloquent'])
+                    ->addDataSource($app['clockwork.cache'])
+                    ->addDataSource($app['clockwork.queue']);
+
+                if ($this->redisAvailable()) {
+                    $clockwork->addDataSource($app['clockwork.redis']);
+                }
+
+                return $clockwork;
+            });
+
             return;
         }
 
@@ -104,12 +175,32 @@ class ClockworkServiceProvider extends ServiceProvider
                 ->addDataSource($app['clockwork.events'])
                 ->addDataSource($app['clockwork.flarum']);
 
+            $clockwork->addDataSource($app['clockwork.queue']);
+
+            if ($this->redisAvailable()) {
+                $clockwork->addDataSource($app['clockwork.redis']);
+            }
+
             if (in_array('xdebug', get_loaded_extensions())) {
                 $clockwork->addDataSource($app['clockwork.xdebug']);
             }
 
             return $clockwork;
         });
+    }
+
+    protected function redisAvailable(): bool
+    {
+        return $this->app->bound(RedisFactory::class);
+    }
+
+    protected function enableRedisEvents(): void
+    {
+        $manager = $this->app->make(RedisFactory::class);
+
+        if (method_exists($manager, 'enableEvents')) {
+            $manager->enableEvents();
+        }
     }
 
     protected function runningInConsole(): bool


### PR DESCRIPTION
## Summary

- **Queue job dispatch tracking** — jobs dispatched during an HTTP request appear in the Queue tab, showing job name, queue, connection, dispatch time, and stack trace. The dispatched job entries link to their execution records via `clockwork_id`/`clockwork_parent_id` injected into the job payload.
- **Queue job execution tracking** — each job processed by the worker is recorded as a separate Clockwork entry (type: `queue-job`) with its own DB queries, cache hits, and log entries. A minimal Clockwork instance is initialised in the worker/console context so job records are stored correctly.
- **Redis command tracking** — when `fof/redis` is active, `LaravelRedisDataSource` is registered and Redis events are enabled via `RedisManager::enableEvents()`. Redis commands appear in the Redis tab per HTTP request and per queue job execution.

## Notes

- Queue and Redis tracking are both guarded: queue tracking is always active (sync jobs are silently skipped by Clockwork's own `SyncJob` check), Redis tracking only activates if `Illuminate\Contracts\Redis\Factory` is bound.
- The worker-side Clockwork instance registers Eloquent, cache, Monolog, queue, and Redis data sources — giving full visibility into what each job does.