### PR TITLE
[1.x] fix: extensions all showing as disabled in Flarum tab

### DIFF
--- a/src/Clockwork/FlarumDataSource.php
+++ b/src/Clockwork/FlarumDataSource.php
@@ -235,7 +235,7 @@ class FlarumDataSource extends DataSource
 
             $formattedExtension = Arr::add($formattedExtension, 'Name', $extension->name);
             $formattedExtension = Arr::add($formattedExtension, 'Version', $extension->getVersion());
-            $formattedExtension = Arr::add($formattedExtension, 'Enabled', $extensionManager->isEnabled($extension->name));
+            $formattedExtension = Arr::add($formattedExtension, 'Enabled', $extensionManager->isEnabled($extension->getId()) ? '✓' : '');
 
             $formattedExtensionList[] = $formattedExtension;
         }


### PR DESCRIPTION
## Summary

`ExtensionManager::isEnabled()` keys enabled extensions by their **ID** (e.g. `fof-clockwork`), not their Composer package name (e.g. `fof/clockwork`). The code was passing `$extension->name` (the package name), so the lookup always failed and every extension appeared as disabled.

Fix: use `$extension->getId()` which returns the correct ID format.

Ported from the 2.x branch.