### PR TITLE
[1.x] fix: add 'assets' folder to asset route for Clockwork 5.3 web UI

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -30,7 +30,7 @@ return [
     (new Extend\Routes('forum'))
         ->get('/__clockwork[/]', 'fof.clockwork.app', Controllers\ClockworkRedirectController::class)
         ->get('/__clockwork/app', 'fof.clockwork.app.web', Controllers\ClockworkWebController::class)
-        ->get('/__clockwork/{folder:(?:css|img|js)}/{path:.+}', 'fof.clockwork.asset', Controllers\ClockworkAssetController::class)
+        ->get('/__clockwork/{folder:(?:assets|css|img|js)}/{path:.+}', 'fof.clockwork.asset', Controllers\ClockworkAssetController::class)
         ->post('/__clockwork/auth', 'fof.clockwork.auth', Controllers\ClockworkAuthController::class)
         ->get('/__clockwork/{request:.+}', 'fof.clockwork.request', Controllers\ClockworkController::class),
 


### PR DESCRIPTION
Clockwork 5.3 rebuilt the web UI with Vite, moving compiled assets from separate `css/` and `js/` directories into a single `assets/` folder with content-hashed filenames. The asset route regex only matched `css`, `img`, and `js` folders, so all asset requests returned 404 and the web UI failed to load.

Adds `assets` to the allowed folder pattern.