### PR TITLE
[2.x] Fix controller bugs, add queue/Redis tracking, bump Clockwork to ^5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,39 +2,99 @@
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg) [![Latest Stable Version](https://img.shields.io/packagist/v/fof/clockwork.svg)](https://packagist.org/packages/fof/clockwork) [![OpenCollective](https://img.shields.io/badge/opencollective-fof-blue.svg)](https://opencollective.com/fof/donate)
 
-A [Flarum](http://flarum.org) extension. Debug your Flarum forum with [Clockwork](https://underground.works/clockwork/).
+A [Flarum](http://flarum.org) extension that integrates [Clockwork](https://underground.works/clockwork/) — a developer tools panel for inspecting and profiling requests in real time.
 
 [![screenshot](https://i.imgur.com/m55k8Rd.png)](https://imgur.com/a/JCD6Wk4)
 
-### Installation
+---
 
-Install with composer:
+## What it does
+
+Once installed and enabled, every HTTP request to your Flarum forum is profiled and stored. You can inspect them using the [Clockwork browser extension](https://underground.works/clockwork/#how-to-use) (available for Chrome and Firefox) or by visiting `/__clockwork` in your browser.
+
+### Performance tab
+
+- **Timeline** — visualises application boot, request processing, controller logic, and data serialisation broken down by phase.
+- **Memory usage** — peak memory consumed per request.
+
+### Database tab
+
+- All SQL queries executed during the request, with bindings, duration, and a stack trace showing where each query originated.
+
+### Cache tab
+
+- Cache hits, misses, writes, and deletes, with keys and values.
+
+### Queue tab
+
+- Jobs dispatched during the request, showing job class, queue name, dispatch time, payload, and stack trace.
+- When using a real queue driver (Redis, database), each processed job appears as a separate entry with its own timeline, queries, cache operations, and logs — linked back to the HTTP request that dispatched it.
+
+### Redis tab
+
+- All Redis commands executed during the request or queue job, with parameters, duration, and connection name. Requires [fof/redis](https://github.com/FriendsOfFlarum/redis) to be installed and active.
+
+### Events tab
+
+- Flarum and Laravel events fired during the request, with counts.
+
+### Flarum tab
+
+- Installed and enabled extension counts.
+- Core version information (Flarum, PHP, MySQL).
+- Full extension list with enabled/disabled status.
+- Frontend document payload (layout view, app view, page payload) for forum and admin page requests.
+
+---
+
+## Installation
 
 ```sh
 composer require fof/clockwork:"*"
 ```
 
-### Updating
+Enable the extension in your Flarum admin panel. Access is restricted to forum administrators.
+
+---
+
+## Updating
 
 ```sh
 composer update fof/clockwork
+php flarum cache:clear
 ```
 
-### Nginx Config
+---
 
-If you're using the `.nginx.conf` file included with Flarum, include the following above the `location /` block:
+## Nginx configuration
 
-```
+If you are using the `.nginx.conf` file included with Flarum, add the following **above** the `location /` block to allow Clockwork's assets and data to be served correctly:
+
+```nginx
 location ~* /__clockwork/.*\.(css|js|json|png|jpg) {
     try_files /index.php?$query_string /index.php?$query_string;
 }
 ```
 
-### Links
+---
+
+## Browser extension
+
+Install the Clockwork browser extension to view profiling data directly in your browser's developer tools:
+
+- [Chrome](https://chrome.google.com/webstore/detail/clockwork/dmggabnehkmmfmdffgajcflpdjlnoemp)
+- [Firefox](https://addons.mozilla.org/en-US/firefox/addon/clockwork-dev-tools/)
+
+Alternatively, visit `https://your-forum.com/__clockwork` to access the built-in web UI without the extension.
+
+---
+
+## Links
 
 [![OpenCollective](https://img.shields.io/badge/donate-friendsofflarum-44AEE5?style=for-the-badge&logo=open-collective)](https://opencollective.com/fof/donate)
 
 - [Packagist](https://packagist.org/packages/fof/clockwork)
 - [GitHub](https://github.com/FriendsOfFlarum/clockwork)
+- [Clockwork](https://underground.works/clockwork/)
 
 An extension by [FriendsOfFlarum](https://github.com/FriendsOfFlarum).

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "license": "MIT",
     "require": {
         "flarum/core": "^2.0",
-        "itsgoingd/clockwork": "5.1.5"
+        "itsgoingd/clockwork": "^5.3"
     },
     "authors": [
         {
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "1.x": "1.x-dev"
+            "dev-2.x": "2.x-dev"
         },
         "flarum-extension": {
             "title": "FoF Clockwork",
@@ -53,7 +53,8 @@
         }
     },
     "require-dev": {
-        "flarum/phpstan": "^2.0"
+        "flarum/phpstan": "^2.0",
+        "fof/redis": "*"
     },
     "scripts": {
         "analyse:phpstan": "phpstan analyse",

--- a/extend.php
+++ b/extend.php
@@ -30,7 +30,7 @@ return [
     (new Extend\Routes('forum'))
         ->get('/__clockwork[/]', 'fof.clockwork.app', Controllers\ClockworkRedirectController::class)
         ->get('/__clockwork/app', 'fof.clockwork.app.web', Controllers\ClockworkWebController::class)
-        ->get('/__clockwork/{folder:(?:css|img|js)}/{path:.+}', 'fof.clockwork.asset', Controllers\ClockworkAssetController::class)
+        ->get('/__clockwork/{folder:(?:assets|css|img|js)}/{path:.+}', 'fof.clockwork.asset', Controllers\ClockworkAssetController::class)
         ->post('/__clockwork/auth', 'fof.clockwork.auth', Controllers\ClockworkAuthController::class)
         ->get('/__clockwork/{request:.+}', 'fof.clockwork.request', Controllers\ClockworkController::class),
 

--- a/itsgoingd/Clockwork/Support/Monolog/Handler/ClockworkHandler.php
+++ b/itsgoingd/Clockwork/Support/Monolog/Handler/ClockworkHandler.php
@@ -18,7 +18,7 @@ use Monolog\LogRecord;
 // Stores messages in a Clockwork log instance
 class ClockworkHandler extends AbstractProcessingHandler
 {
-    protected $clockworkLog;
+    protected ClockworkLog $clockworkLog;
 
     public function __construct(ClockworkLog $clockworkLog)
     {

--- a/js/src/admin/extend.ts
+++ b/js/src/admin/extend.ts
@@ -2,4 +2,7 @@ import Extend from 'flarum/common/extenders';
 
 import ClockworkPage from './components/ClockworkPage';
 
-export default [new Extend.Admin().page(ClockworkPage)];
+export default [
+  new Extend.Admin() //
+    .page(ClockworkPage),
+];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,8 +2,7 @@ includes:
   - vendor/flarum/phpstan/extension.neon
 
 parameters:
-  # The level will be increased in Flarum 2.0
-  level: 5
+  level: 6
   paths:
     - extend.php
     - src

--- a/src/AddFrontendData.php
+++ b/src/AddFrontendData.php
@@ -26,7 +26,7 @@ class AddFrontendData
         $this->container = $container;
     }
 
-    public function __invoke($document = null)
+    public function __invoke(mixed $document = null): void
     {
         if ($this->container->bound('clockwork.flarum')) {
             if (!$document instanceof Document) {

--- a/src/Clockwork/FlarumAuthenticator.php
+++ b/src/Clockwork/FlarumAuthenticator.php
@@ -16,26 +16,26 @@ use Flarum\Http\RequestUtil;
 
 class FlarumAuthenticator implements AuthenticatorInterface
 {
-    protected $groupId;
+    protected int $groupId;
 
-    public function __construct($groupId)
+    public function __construct(int $groupId)
     {
         $this->groupId = $groupId;
     }
 
-    public function attempt(array $credentials)
+    public function attempt(array $credentials): bool
     {
         return true;
     }
 
-    public function check($request)
+    public function check(mixed $request): bool
     {
         $user = RequestUtil::getActor($request);
 
         return !$user->isGuest() && $user->groups->contains($this->groupId);
     }
 
-    public function requires()
+    public function requires(): array
     {
         return [];
     }

--- a/src/Clockwork/FlarumDataSource.php
+++ b/src/Clockwork/FlarumDataSource.php
@@ -38,27 +38,16 @@ class FlarumDataSource extends DataSource
      */
     protected $container;
 
-    /**
-     * Log data structure.
-     */
-    protected $log;
+    protected ?Log $log = null;
 
-    /**
-     * Timeline data structure.
-     */
-    protected $timeline;
+    protected Timeline $timeline;
 
-    /**
-     * @var ServerRequestInterface
-     */
-    protected $request;
+    protected ServerRequestInterface $request;
 
-    /**
-     * @var ResponseInterface
-     */
-    protected $response;
+    protected ResponseInterface $response;
 
-    public $count;
+    /** @var array<string, int> */
+    public array $count = [];
 
     /**
      * Create a new data source, takes Laravel container instance as an argument.
@@ -73,7 +62,7 @@ class FlarumDataSource extends DataSource
     /**
      * Adds request method, uri, controller, headers, response status, timeline data and log entries to the request.
      */
-    public function resolve(Request $request)
+    public function resolve(Request $request): Request
     {
         $request->sessionData = $this->getSessionData();
 
@@ -89,21 +78,21 @@ class FlarumDataSource extends DataSource
     }
 
     // Set a log instance
-    public function setLog(Log $log)
+    public function setLog(Log $log): static
     {
         $this->log = $log;
 
         return $this;
     }
 
-    public function setResponse(ResponseInterface $response)
+    public function setResponse(ResponseInterface $response): static
     {
         $this->response = $response;
 
         return $this;
     }
 
-    public function setRequest(ServerRequestInterface $request)
+    public function setRequest(ServerRequestInterface $request): static
     {
         $this->request = $request;
 
@@ -113,7 +102,7 @@ class FlarumDataSource extends DataSource
     /**
      * Hook up callbacks for various Laravel events, providing information for timeline and log entries.
      */
-    public function listenToEvents()
+    public function listenToEvents(): void
     {
         $this->container['events']->listen('clockwork.middleware.start', function () {
             $this->timeline->event('Request processing')->color('purple')->begin();
@@ -146,7 +135,7 @@ class FlarumDataSource extends DataSource
     /**
      * Hook up callbacks for some Laravel events, that we need to register as soon as possible.
      */
-    public function listenToEarlyEvents()
+    public function listenToEarlyEvents(): void
     {
         $this->timeline->event('Total execution time')->begin();
         $this->timeline->event('Application booting')->begin();
@@ -184,7 +173,7 @@ class FlarumDataSource extends DataSource
     /**
      * Return session data (replace unserializable items, attempt to remove passwords).
      */
-    protected function getSessionData()
+    protected function getSessionData(): array
     {
         $session = $this->request->getattribute('session');
 
@@ -192,7 +181,7 @@ class FlarumDataSource extends DataSource
     }
 
     // Add authenticated user data to the request
-    protected function resolveAuthenticatedUser(Request $request)
+    protected function resolveAuthenticatedUser(Request $request): void
     {
         $user = RequestUtil::getActor($this->request);
         if ($user->isGuest()) {
@@ -210,7 +199,7 @@ class FlarumDataSource extends DataSource
         $this->request->getServerParams();
     }
 
-    public function addDocumentData(?Document $document = null)
+    public function addDocumentData(?Document $document = null): void
     {
         $this->timeline->event('Clockwork')->begin();
 
@@ -321,7 +310,7 @@ class FlarumDataSource extends DataSource
         }
     }
 
-    public function authenticate(RequestInterface $request)
+    public function authenticate(RequestInterface $request): bool
     {
         $authenticator = $this->container['clockwork']->getAuthenticator();
 

--- a/src/Clockwork/QueueJobTracker.php
+++ b/src/Clockwork/QueueJobTracker.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of fof/clockwork.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Clockwork\Clockwork;
+
+use Clockwork\Request\Request;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Jobs\SyncJob;
+
+class QueueJobTracker
+{
+    /**
+     * @var Container
+     */
+    private $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    public function listenToEvents(): void
+    {
+        $this->container['events']->listen(JobProcessing::class, function (JobProcessing $event) {
+            // Sync jobs are recorded as part of the parent HTTP request
+            if ($event->job instanceof SyncJob) {
+                return;
+            }
+
+            $payload = $event->job->payload();
+
+            if (!isset($payload['clockwork_id'])) {
+                return;
+            }
+
+            $request = new Request(['id' => $payload['clockwork_id']]);
+
+            if (isset($payload['clockwork_parent_id'])) {
+                $request->setParent($payload['clockwork_parent_id']);
+            }
+
+            $this->container->make('clockwork')->reset()->request($request);
+
+            $this->container['clockwork.queue']->setCurrentRequestId($request->id);
+        });
+
+        $this->container['events']->listen(JobProcessed::class, function (JobProcessed $event) {
+            $this->processJob($event->job);
+        });
+
+        $this->container['events']->listen(JobFailed::class, function (JobFailed $event) {
+            $this->processJob($event->job, $event->exception);
+        });
+    }
+
+    protected function processJob(Job $job, ?\Throwable $exception = null): void
+    {
+        // Sync jobs are recorded as part of the parent HTTP request
+        if ($job instanceof SyncJob) {
+            return;
+        }
+
+        $payload = $job->payload();
+
+        if (!isset($payload['clockwork_id'])) {
+            return;
+        }
+
+        $unserialized = isset($payload['data']['command']) ? unserialize($payload['data']['command']) : null;
+
+        if (!$unserialized) {
+            return;
+        }
+
+        $clockwork = $this->container->make('clockwork');
+
+        if ($exception) {
+            $clockwork->error($exception->getMessage(), ['exception' => $exception]);
+        }
+
+        $clockwork
+            ->resolveAsQueueJob(
+                get_class($unserialized),
+                $payload['displayName'],
+                $job->hasFailed() ? 'failed' : ($job->isReleased() ? 'released' : 'done'),
+                $unserialized,
+                $job->getQueue(),
+                $job->getConnectionName(),
+                array_filter([
+                    'maxTries'     => $payload['maxTries'] ?? null,
+                    'delaySeconds' => $payload['delaySeconds'] ?? null,
+                    'timeout'      => $payload['timeout'] ?? null,
+                    'timeoutAt'    => $payload['timeoutAt'] ?? null,
+                ])
+            )
+            ->storeRequest();
+    }
+}

--- a/src/Controllers/ClockworkAuthController.php
+++ b/src/Controllers/ClockworkAuthController.php
@@ -11,6 +11,7 @@
 
 namespace FoF\Clockwork\Controllers;
 
+use Flarum\Http\RequestUtil;
 use Illuminate\Contracts\Container\Container;
 use Laminas\Diactoros\Response\JsonResponse;
 use Psr\Http\Message\ResponseInterface;
@@ -37,7 +38,7 @@ class ClockworkAuthController implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $token = $this->container['clockwork.authenticator']->attempt(
-            ['actor' => $request->getAttribute('actor')]
+            ['actor' => RequestUtil::getActor($request)]
         );
 
         return new JsonResponse(['token' => $token], $token ? 200 : 403);

--- a/src/Controllers/ClockworkController.php
+++ b/src/Controllers/ClockworkController.php
@@ -11,7 +11,7 @@
 
 namespace FoF\Clockwork\Controllers;
 
-use Flarum\Http\Exception\RouteNotFoundException;
+use Clockwork\Storage\Search;
 use Illuminate\Contracts\Container\Container;
 use Laminas\Diactoros\Response\JsonResponse;
 use Psr\Http\Message\ResponseInterface;
@@ -47,13 +47,38 @@ class ClockworkController implements RequestHandlerInterface
             ], 403);
         }
 
-        $req = $request->getQueryParams()['request'];
-        $metadata = $this->container['clockwork']->getMetadata($req);
+        // Flarum merges route params into query params (RouteHandlerFactory).
+        // The {request:.+} route param captures e.g. "latest", "{id}", "{id}/previous", "{id}/next/50"
+        $path = $request->getQueryParams()['request'] ?? '';
+        $parts = explode('/', $path);
 
-        if ($metadata == null) {
-            throw new RouteNotFoundException();
+        $id = $parts[0] ?? null;
+        $direction = $parts[1] ?? null;
+        $count = isset($parts[2]) ? (int) $parts[2] : null;
+
+        $storage = $this->container['clockwork']->getClockwork()->storage();
+        $search = Search::fromRequest($request->getQueryParams());
+
+        if ($direction === 'previous') {
+            $data = $storage->previous($id, $count, $search);
+        } elseif ($direction === 'next') {
+            $data = $storage->next($id, $count, $search);
+        } elseif ($id === 'latest') {
+            $data = $storage->latest($search);
+        } else {
+            $data = $storage->find($id);
         }
 
-        return new JsonResponse($metadata);
+        if ($data === null || $data === false) {
+            return new JsonResponse(['message' => 'Not found.'], 404);
+        }
+
+        if (is_array($data)) {
+            $data = array_map(fn ($r) => $r->toArray(), $data);
+        } else {
+            $data = $data->toArray();
+        }
+
+        return new JsonResponse($data);
     }
 }

--- a/src/Provider/ClockworkServiceProvider.php
+++ b/src/Provider/ClockworkServiceProvider.php
@@ -14,24 +14,37 @@ namespace FoF\Clockwork\Provider;
 use Clockwork\DataSource\EloquentDataSource;
 use Clockwork\DataSource\LaravelCacheDataSource;
 use Clockwork\DataSource\LaravelEventsDataSource;
+use Clockwork\DataSource\LaravelQueueDataSource;
+use Clockwork\DataSource\LaravelRedisDataSource;
 use Clockwork\DataSource\MonologDataSource;
 use Clockwork\DataSource\XdebugDataSource;
 use Clockwork\Request\Log;
-use Clockwork\Support\Laravel\ClockworkSupport;
 use Clockwork\Support\Vanilla\Clockwork;
 use Flarum\Foundation\Paths;
 use Flarum\Group\Group;
 use FoF\Clockwork\Clockwork\FlarumAuthenticator;
 use FoF\Clockwork\Clockwork\FlarumDataSource;
+use FoF\Clockwork\Clockwork\QueueJobTracker;
 use FoF\Clockwork\Middleware\BeforeRouteExecutionMiddleware;
 use FoF\Clockwork\Middleware\ClockworkMiddleware;
+use Illuminate\Contracts\Redis\Factory as RedisFactory;
+use Illuminate\Redis\RedisManager;
 use Illuminate\Support\ServiceProvider;
 
 class ClockworkServiceProvider extends ServiceProvider
 {
-    public function boot()
+    public function boot(): void
     {
+        $this->app['clockwork.queue.tracker']->listenToEvents();
+
         if ($this->runningInConsole()) {
+            $this->app['clockwork.eloquent']->listenToEvents();
+            $this->app['clockwork.cache']->listenToEvents();
+            if ($this->redisAvailable()) {
+                $this->enableRedisEvents();
+                $this->app['clockwork.redis']->listenToEvents();
+            }
+
             return;
         }
 
@@ -39,6 +52,16 @@ class ClockworkServiceProvider extends ServiceProvider
         $this->app['clockwork.cache']->listenToEvents();
         $this->app['clockwork.flarum']->listenToEvents();
         $this->app['clockwork.events']->listenToEvents();
+
+        if ($this->redisAvailable()) {
+            $this->enableRedisEvents();
+            $this->app['clockwork.redis']->listenToEvents();
+        }
+
+        $this->app['clockwork.queue']->listenToEvents();
+        $this->app['clockwork.queue']->setCurrentRequestId(
+            $this->app->make('clockwork')->getClockwork()->request()->id
+        );
 
         // This is done to dispatch an event right before controller execution,
         // and after all middleware, including extension middleware.
@@ -51,22 +74,67 @@ class ClockworkServiceProvider extends ServiceProvider
         }
 
         // Remove the clockwork middleware from API Client handling
-        $this->app->extend('flarum.api_client.exclude_middleware', function (array $exlusions) {
-            $exlusions[] = ClockworkMiddleware::class;
+        $this->app->extend('flarum.api_client.exclude_middleware', function (array $exclusions) {
+            $exclusions[] = ClockworkMiddleware::class;
 
-            return $exlusions;
+            return $exclusions;
         });
     }
 
     public function register()
     {
+        $this->app->singleton('clockwork.queue', function ($app) {
+            /** @var \Illuminate\Queue\Queue $connection */
+            $connection = $app->make('flarum.queue.connection');
+
+            return new LaravelQueueDataSource($connection);
+        });
+
+        $this->app->singleton('clockwork.queue.tracker', function ($app) {
+            return new QueueJobTracker($app);
+        });
+
+        $this->app->singleton('clockwork.redis', function ($app) {
+            return new LaravelRedisDataSource($app['events']);
+        });
+
         if ($this->runningInConsole()) {
+            $this->app->singleton('clockwork.log', function () {
+                return new Log();
+            });
+
+            $this->app->singleton('clockwork.eloquent', function ($app) {
+                return new EloquentDataSource($app['db'], $app['events']);
+            });
+
+            $this->app->singleton('clockwork.cache', function ($app) {
+                return new LaravelCacheDataSource($app['events']);
+            });
+
+            $this->app->singleton('clockwork', function ($app) {
+                $paths = resolve(Paths::class);
+
+                /** @var Clockwork|\Clockwork\Clockwork $clockwork */
+                $clockwork = Clockwork::init([
+                    'enable'             => true,
+                    'storage_files_path' => $paths->storage.'/clockwork',
+                ]);
+
+                $clockwork
+                    ->addDataSource(new MonologDataSource($app['log']))
+                    ->addDataSource($app['clockwork.eloquent'])
+                    ->addDataSource($app['clockwork.cache'])
+                    ->addDataSource($app['clockwork.queue']);
+
+                if ($this->redisAvailable()) {
+                    $clockwork->addDataSource($app['clockwork.redis']);
+                }
+
+                return $clockwork;
+            });
+
             return;
         }
-
-        $this->app->singleton('clockwork.support', function ($app) {
-            return new ClockworkSupport($app);
-        });
 
         $this->app->singleton('clockwork.authenticator', function () {
             return new FlarumAuthenticator(Group::ADMINISTRATOR_ID);
@@ -86,8 +154,8 @@ class ClockworkServiceProvider extends ServiceProvider
 
         $this->app->singleton('clockwork.events', function ($app) {
             return new LaravelEventsDataSource($app['events'], [
-                'Flarum\\\\Event\\\\.+',
-                'Flarum\\\\Api\\\\Event\\\\.+',
+                'Flarum\\\\\\\\Event\\\\\\\\.+',
+                'Flarum\\\\\\\\Api\\\\\\\\Event\\\\\\\\.+',
             ]);
         });
 
@@ -121,12 +189,32 @@ class ClockworkServiceProvider extends ServiceProvider
                 ->addDataSource($app['clockwork.events'])
                 ->addDataSource($app['clockwork.flarum']);
 
+            $clockwork->addDataSource($app['clockwork.queue']);
+
+            if ($this->redisAvailable()) {
+                $clockwork->addDataSource($app['clockwork.redis']);
+            }
+
             if (in_array('xdebug', get_loaded_extensions())) {
                 $clockwork->addDataSource($app['clockwork.xdebug']);
             }
 
             return $clockwork;
         });
+    }
+
+    protected function redisAvailable(): bool
+    {
+        return $this->app->bound(RedisFactory::class);
+    }
+
+    protected function enableRedisEvents(): void
+    {
+        $manager = $this->app->make(RedisFactory::class);
+
+        if ($manager instanceof RedisManager) {
+            $manager->enableEvents();
+        }
     }
 
     protected function runningInConsole(): bool


### PR DESCRIPTION
Ports all outstanding 1.x changes to the 2.x branch.

## Changes

**Bug fixes (closes #24)**
- `ClockworkController`: rewritten to use the Clockwork storage API (`find`, `latest`, `previous`, `next`) instead of the non-existent `getMetadata()` call
- `ClockworkAuthController`: use `RequestUtil::getActor()` instead of `$request->getAttribute('actor')`
- `LaravelEventsDataSource`: fix broken regex escape sequences so Flarum events are captured correctly
- Remove unused `ClockworkSupport` singleton
- Fix `$exlusions` typo → `$exclusions`

**Clockwork web UI fix (from 1.x #32)**
- Asset route regex was missing `assets` from the folder group, breaking the Clockwork 5.3 web UI

**Queue and Redis tracking (closes #27)**
- Add `QueueJobTracker` for tracking queue job lifecycle events
- Add `LaravelQueueDataSource` registration
- Add `LaravelRedisDataSource` registration when `fof/redis` is active
- Add worker-side Clockwork console initialisation

**Dependency bump (closes #28)**
- `itsgoingd/clockwork`: `5.1.5` → `^5.3`

**PHPStan**
- Bump to level 6 and resolve all resulting type errors

**README (closes #30)**
- Rewrite with full feature documentation covering all tabs (Performance, Database, Cache, Queue, Redis, Events, Flarum), installation, nginx config, and browser extension links